### PR TITLE
added Windows support

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,18 @@
+
+cmake -G "NMake Makefiles" ^
+      -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D TIFF_LIBRARY=%LIBRARY_LIB%\libtiff.lib ^
+      -D TIFF_INCLUDE_DIR=%LIBRARY_INC% ^
+      -D PNG_LIBRARY_RELEASE=%LIBRARY_LIB%\libpng.lib ^
+      -D PNG_PNG_INCLUDE_DIR=%LIBRARY_INC% ^
+      -D ZLIB_LIBRARY=%LIBRARY_LIB%\zlib.lib ^
+      -D ZLIB_INCLUDE_DIR=%LIBRARY_INC% ^
+      -D CMAKE_BUILD_TYPE=Release ^
+      .
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,9 @@ source:
 build:
     number: 1
     features:
-        - vc9 [win and py27]
-        - vc10 [win and py34]
-        - vc14 [win and py35]
+        - vc9  # [win and py27]
+        - vc10  # [win and py34]
+        - vc14  # [win and py35]
 
 requirements:
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,14 @@ source:
 
 build:
     number: 1
-    skip: True  # [win]
+    features:
+        - vc9 [win and py27]
+        - vc10 [win and py34]
+        - vc14 [win and py35]
 
 requirements:
     build:
+        - python [win]
         - cmake
         - libtiff
         - libpng


### PR DESCRIPTION
This PR adds Windows support to the build. 

I was only able to get the VC features working by making Python a build dependency - let me know if I have done this right. I seem to be able to switch between VC versions with the --python=x.x option to conda build.
