### PR TITLE
Pin libtiff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://www.openjpeg.org/
 
 Package license: BSD 2-clauses
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: An open-source JPEG 2000 codec written in C
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,12 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    - cmd: conda install --yes conda-build=1.20.0
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
     md5: 3e1c451c087f8462955426da38aa3b3d
 
 build:
-    number: 3
+    number: 4
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]
@@ -18,11 +18,11 @@ requirements:
     build:
         - python  # [win]
         - cmake
-        - libtiff 4*
+        - libtiff 4.0.6
         - libpng 1.6*
         - zlib 1.2*
     run:
-        - libtiff 4*
+        - libtiff 4.0.6
         - libpng 1.6*
         - zlib 1.2*
 


### PR DESCRIPTION
Pinning exactly to `4.0.6` ensure we get the `libtiff` compiled against `jpeg 9b`.
